### PR TITLE
F/cloud 1763 v4 bump

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.74.1
+    rev: v1.71.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -20,6 +20,6 @@ repos:
           - "--args=--only=terraform_standard_module_structure"
           - "--args=--only=terraform_workspace_remote"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.2.0
     hooks:
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.51.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -19,7 +19,7 @@ repos:
           - "--args=--only=terraform_required_providers"
           - "--args=--only=terraform_standard_module_structure"
           - "--args=--only=terraform_workspace_remote"
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Refer [examples](examples)
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=3.66.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.22.0 |
 | <a name="requirement_postgresql"></a> [postgresql](#requirement\_postgresql) | >=1.14.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 

--- a/versions.tf
+++ b/versions.tf
@@ -10,7 +10,7 @@ terraform {
 
     aws = {
       source  = "hashicorp/aws"
-      version = ">=3.66.0"
+      version = "~> 4.22.0"
     }
 
     random = {


### PR DESCRIPTION
> **WARNING**: Should be tagged as v1.0 as that's the version used in TVA
> and we use 3 different tags on 3 places
> 1. v1.1 [trailers-api](https://github.com/variant-inc/trailers-api/blob/de5779dbb990d6b6fbba52375687ccc8727b66ef/terraform/Variant.Trailers.Api/trailers_database.tf#L2)
> 2. v1 [ticketing](https://github.com/variant-inc/ticketing/blob/c4ee482ccaefee5370bcd32cce230a4b88c115eb/terraform/Variant.Ticketing.Api/database.tf#L75)
> 3. v1.0 [TVA](https://github.com/variant-inc/terragrunt-variant-apps/blob/37f01e6ea419662203b8be3985208a2998b0ba2a/modules/common/postgres/main.tf#L15)

# Description

Part of changes in [92](https://github.com/variant-inc/terragrunt-variant-apps/pull/92)


## Type of change

- [x] New feature (non-breaking change which adds functionality)