### PR TITLE
H/secret output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.71.0
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -20,6 +20,6 @@ repos:
           - "--args=--only=terraform_standard_module_structure"
           - "--args=--only=terraform_workspace_remote"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -69,5 +69,6 @@ No modules.
 | <a name="output_database"></a> [database](#output\_database) | Name of the Database |
 | <a name="output_password"></a> [password](#output\_password) | Password of the User |
 | <a name="output_secret_id"></a> [secret\_id](#output\_secret\_id) | ID of Secret in SecretsManager |
+| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | Name of Secret in SecretsManager |
 | <a name="output_user"></a> [user](#output\_user) | Name of the User |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_secretsmanager_secret_rotation" "database_credentials" {
   secret_id           = aws_secretsmanager_secret.database_credentials.id
 
   rotation_rules {
-    automatically_after_days = 30
+    automatically_after_days = 90
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,3 +18,8 @@ output "secret_id" {
   value       = aws_secretsmanager_secret.database_credentials.id
   description = "ID of Secret in SecretsManager"
 }
+
+output "secret_name" {
+  value       = "postgres-secret-${var.database_name}"
+  description = "Name of Secret in SecretsManager"
+}


### PR DESCRIPTION
# Description

Small benign change which added an additional output for secret names as well as increasing the duration before a secret rotation is performed.

Fixes [#8](https://usxtech.atlassian.net/browse/CLOUD-8)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This has been tested using DX with the latest version of cake runner. Currently the application is running under the name "cake-external-secret-test-7575f5c675-k7gjh" and referenced the terraform-postgres-database branch 'h/secret-output'. It is located in the DPL cluster.

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added documentation to test
